### PR TITLE
Make it work with rails 3.0.1

### DIFF
--- a/meta_where.gemspec
+++ b/meta_where.gemspec
@@ -105,19 +105,19 @@ you're feeling especially appreciative. It'd help me justify this
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_runtime_dependency(%q<activerecord>, ["~> 3.0.0"])
-      s.add_runtime_dependency(%q<activesupport>, ["~> 3.0.0"])
+      s.add_runtime_dependency(%q<activerecord>, ["~> 3.0.1"])
+      s.add_runtime_dependency(%q<activesupport>, ["~> 3.0.1"])
       s.add_runtime_dependency(%q<arel>, ["~> 1.0.1"])
     else
       s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<activerecord>, ["~> 3.0.0"])
-      s.add_dependency(%q<activesupport>, ["~> 3.0.0"])
+      s.add_dependency(%q<activerecord>, ["~> 3.0.1"])
+      s.add_dependency(%q<activesupport>, ["~> 3.0.1"])
       s.add_dependency(%q<arel>, ["~> 1.0.1"])
     end
   else
     s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<activerecord>, ["~> 3.0.0"])
-    s.add_dependency(%q<activesupport>, ["~> 3.0.0"])
+    s.add_dependency(%q<activerecord>, ["~> 3.0.1"])
+    s.add_dependency(%q<activesupport>, ["~> 3.0.1"])
     s.add_dependency(%q<arel>, ["~> 1.0.1"])
   end
 end


### PR DESCRIPTION
hi there,

just updated the version number in the gemspec to work with rails 3.0.1. One could also think about using `~> 3.0` which will allow all version _greater than 3.0_ and _smaller than 3.1_. all tests pass:

```
meta_where$ rake test
(in /Users/secret/Desktop/meta_where)
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -I"lib:lib:test:vendor/rails/activerecord/lib:vendor/rails/activesupport/lib:vendor/arel/lib" "/Library/Ruby/Gems/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader.rb" "test/test_base.rb" "test/test_relations.rb" 
Loaded suite /Library/Ruby/Gems/1.8/gems/rake-0.8.7/lib/rake/rake_test_loader
Started
.....................................
Finished in 0.601101 seconds.

37 tests, 59 assertions, 0 failures, 0 errors
```

greetings,
patrick
