### PR TITLE
Added support for Not

### DIFF
--- a/lib/core_ext/hash.rb
+++ b/lib/core_ext/hash.rb
@@ -7,4 +7,8 @@ class Hash
   def &(other)
     MetaWhere::And.new(self, other)
   end
+
+  def -(other)
+    MetaWhere::Not.new(self, other)
+  end
 end

--- a/lib/meta_where/compound.rb
+++ b/lib/meta_where/compound.rb
@@ -14,11 +14,18 @@ module MetaWhere
     def &(other)
       And.new(self, other)
     end
+
+    def -(other)
+      Not.new(self, other)
+    end
   end
 
   class Or < Compound
   end
 
   class And < Compound
+  end
+
+  class Not < Compound
   end
 end

--- a/lib/meta_where/condition.rb
+++ b/lib/meta_where/condition.rb
@@ -29,6 +29,10 @@ module MetaWhere
       And.new(self, other)
     end
 
+    def -(other)
+      Not.new(self, other)
+    end
+
     # Play "nicely" with expand_hash_conditions_for_aggregates
     def to_sym
       self

--- a/lib/meta_where/visitors/predicate.rb
+++ b/lib/meta_where/visitors/predicate.rb
@@ -5,7 +5,7 @@ module MetaWhere
     class Predicate < Visitor
 
       def self.visitables
-        [Hash, Array, MetaWhere::Or, MetaWhere::And, MetaWhere::Condition, MetaWhere::Function]
+        [Hash, Array, MetaWhere::Or, MetaWhere::And, MetaWhere::Not, MetaWhere::Condition, MetaWhere::Function]
       end
 
       def visit_Hash(o, parent)
@@ -16,7 +16,7 @@ module MetaWhere
           if value.is_a?(Hash)
             association = association_from_parent_and_column(parent, column)
             accept(value, association || column)
-          elsif [MetaWhere::Condition, MetaWhere::And, MetaWhere::Or].include?(value.class)
+          elsif [MetaWhere::Condition, MetaWhere::And, MetaWhere::Or, MetaWhere::Not].include?(value.class)
             association = association_from_parent_and_column(parent, column)
             accept(value, association || column)
           elsif value.is_a?(Array) && !value.empty? && value.all? {|v| can_accept?(v)}
@@ -75,6 +75,10 @@ module MetaWhere
 
       def visit_MetaWhere_And(o, parent)
         accept(o.condition1, parent).and(accept(o.condition2, parent))
+      end
+
+      def visit_MetaWhere_Not(o, parent)
+        accept(o.condition1, parent).and(accept(o.condition2, parent).not)
       end
 
       def visit_MetaWhere_Condition(o, parent)

--- a/test/test_relations.rb
+++ b/test/test_relations.rb
@@ -115,11 +115,13 @@ class TestRelations < Test::Unit::TestCase
       assert_equal @r.where(:name.like % 'Advanced%').all, @r.where('name LIKE ?', 'Advanced%').all
     end
 
-    should "allow | and & for compound predicates" do
+    should "allow |, &, and - for compound predicates" do
       assert_equal @r.where(:name.like % 'Advanced%' | :name.like % 'Init%').all,
                    @r.where('name LIKE ? OR name LIKE ?', 'Advanced%', 'Init%').all
       assert_equal @r.where(:name.like % 'Mission%' & :name.like % '%Data').all,
                    @r.where('name LIKE ? AND name LIKE ?', 'Mission%', '%Data').all
+      assert_equal @r.where(:name.like % 'Mission%' - :name.like % '%Data').all,
+                   @r.where('name LIKE ? AND name NOT LIKE ?', 'Mission%', '%Data').all
     end
 
     should "allow nested conditions hashes to have array values" do
@@ -140,6 +142,11 @@ class TestRelations < Test::Unit::TestCase
     should "allow nested conditions hashes to have MetaWhere::Or values" do
       assert_equal @r.joins(:data_types).where(:data_types => [:dec.gteq % 2 | :bln.eq % true]).all,
                    @r.joins(:data_types).where(:data_types => ((:dec >= 2) | (:bln >> true))).all
+    end
+
+    should "allow nested conditions hashes to have MetaWhere::Not values" do
+      assert_equal @r.joins(:data_types).where(:data_types => [:dec.gteq % 2 - :bln.eq % true]).all,
+                   @r.joins(:data_types).where(:data_types => ((:dec >= 2) - (:bln >> true))).all
     end
 
     should "allow combinations of options that no sane developer would ever try to use" do


### PR DESCRIPTION
Used in the same way as the other unary operators:

| (Or), & (And), - (Not)
