### PR TITLE
Added OR and NOT operators for ActiveRecord::Relation instances

### DIFF
--- a/lib/meta_where/relation.rb
+++ b/lib/meta_where/relation.rb
@@ -26,6 +26,14 @@ module MetaWhere
       super(r)
     end
 
+    def -(other)
+      klass.where(where_values.inject(:&) - other.where_values.inject(:&))
+    end
+
+    def |(other)
+      klass.where(where_values.inject(:&) | other.where_values.inject(:&))
+    end
+
     def reset_with_metawhere
       @mw_unique_joins = @mw_association_joins = @mw_non_association_joins =
         @mw_stashed_association_joins = @mw_custom_joins = nil

--- a/test/test_relations.rb
+++ b/test/test_relations.rb
@@ -270,6 +270,28 @@ class TestRelations < Test::Unit::TestCase
     end
   end
 
+  context "A NOTed relation with the same base class" do
+    setup do
+      @r = Developer.where(:salary.gteq => 70000) - Developer.where(:company_id.not_eq => 2)
+    end
+
+    should "have identical sql as using the NOT on the hashes" do
+      assert_equal Developer.where({:salary.gteq => 70000} - {:company_id.not_eq => 2}).to_sql,
+                   @r.to_sql
+    end
+  end
+
+  context "An ORed relation with the same base class" do
+    setup do
+      @r = Developer.where(:salary.gteq => 70000) | Developer.where(:company_id.not_eq => 2)
+    end
+
+    should "have identical sql as using the NOT on the hashes" do
+      assert_equal Developer.where({:salary.gteq => 70000} | {:company_id.not_eq => 2}).to_sql,
+                   @r.to_sql
+    end
+  end
+
   context "A Person relation" do
     setup do
       @r = Person.scoped


### PR DESCRIPTION
Now we can do:

```
Developer.where(:salary.gt => 70000) - Developer.where(:company_id.not_eq => 2)
```
