### PR TITLE
Set Operators

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,10 @@ Changes since 1.0.0 (2011-01-17):
   * Add support for NOT operator (-) on hashes, conditions, and compound
     conditions. Unary NOTs the condition, binary does an AND NOT between
     on the second condition.
+  * SQL Set Operators on ActiveRecord::Relation sets. Activate using
+    MetaWhere.set_operator_overload! '&' will be used for
+    INTERSECT. Use ActiveRecord::Relation#merge for the previous
+    functionality.
 
 Changes since 0.9.10 (2011-01-06):
   * Doc updates only, and a version change to 1.0.0.

--- a/README.rdoc
+++ b/README.rdoc
@@ -149,6 +149,57 @@ parentheses around everything. So MetaWhere also supports a substitution-inspire
 
 (*) Formatting added for clarity. I said you could do this, not that you should. :)
 
+== SQL Set Operations
+MetaWhere allows SQL Set Operations by using | (Union), + (UnionAll), & (Intersect) and - (Except/Minus) on ActiveRecord::Relation sets.
+
+The syntax convention for each set operator is borrwed from Ruby's Array class.
+
+You must call MetaWhere.set_operator_overload! to activate. This will overwrite the existing ActiveRecord::Relation#& method. (alias for ActiveRecord::Relation#merge)
+
+Union
+
+  (Acticle.where(:created_at.gt => 2.days.ago) | Article.where(:created_at.lt => 2.weeks.ago)).to_sql
+  => SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" > '2011-02-29 05:57:54.924258'
+     UNION
+     SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" < '2011-02-15 05:57:54.924258'
+
+UnionAll
+
+  (Acticle.where(:created_at.gt => 2.days.ago) + Article.where(:created_at.lt => 2.weeks.ago)).to_sql
+  => SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" > '2011-02-29 05:57:54.924258'
+     UNION ALL
+     SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" < '2011-02-15 05:57:54.924258'
+
+Intersect
+
+  (Acticle.where(:created_at.lt => 2.days.ago) & Article.where(:created_at.gt => 2.weeks.ago)).to_sql
+  => SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" < '2011-02-29 05:57:54.924258'
+     INTERSECT
+     SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" > '2011-02-15 05:57:54.924258'
+
+Except (Minus in Oracle)
+
+  (Acticle.where(:created_at.in => 10.days.ago..1.day.ago) - Article.where(:created_at.in => 15.days.ago..7.days.ago)).to_sql
+  => SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" BETWEEN '2011-02-21 05:57:54.924258' AND '2011-02-30 05:57:54.924258'
+     EXCEPT
+     SELECT "article.*"
+     FROM "article"
+     WHERE "articles"."created_at" BETWEEN '2011-02-16 05:57:54.924258' AND '2011-02-24 05:57:54.924258'
+
 == Join type specification
 You can choose whether to use an inner join (the default) or a left outer join by tacking
 <tt>.outer</tt> or <tt>.inner</tt> to the symbols specified in your joins() call:

--- a/lib/meta_where.rb
+++ b/lib/meta_where.rb
@@ -25,6 +25,11 @@ module MetaWhere
   def self.operator_overload!
     require 'core_ext/symbol_operators'
   end
+
+  def self.set_operator_overload!
+    require 'meta_where/set_operators'
+    ActiveRecord::Relation.send(:include, MetaWhere::SetOperators)
+  end
 end
 
 require 'arel'

--- a/lib/meta_where/set_operators.rb
+++ b/lib/meta_where/set_operators.rb
@@ -1,0 +1,27 @@
+module MetaWhere
+  module SetOperators
+
+    def self.included(base)
+      base.class_eval do
+        remove_method :&
+      end
+    end
+
+    def |(other)
+      arel.union(other)
+    end
+
+    def +(other)
+      arel.union(:all, other)
+    end
+
+    def &(other)
+      arel.intersect(other)
+    end
+
+    def -(other)
+      arel.except(other)
+    end
+
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,7 @@ require 'active_support/time'
 require 'meta_where'
 
 MetaWhere.operator_overload!
+MetaWhere.set_operator_overload!
 
 FIXTURES_PATH = File.join(File.dirname(__FILE__), 'fixtures')
 


### PR DESCRIPTION
SQL Set Operators are now backported to Arel-2-0-stable: https://github.com/rails/arel/commit/9e816c406399139d9ca76d2089df7f2d94d4fb8b
And should (hopefully) be part of the next release of Rails (3.0.4)

We can use this to do Set operators on ActiveRecord::Relation sets.

I'm using the convention from the Array class:
- '|' => Union
- '+' => UnionALL
- '&' => Intersect
- '-' => Except (Minus for Oracle)

The '&' has been removed as an alias for ActiveRecord::Relation.merge.
