### PR TITLE
Fixing dependencies for Rails 3.1.x

### DIFF
--- a/meta_where.gemspec
+++ b/meta_where.gemspec
@@ -35,8 +35,8 @@ you're feeling especially appreciative. It'd help me justify this
 
   s.rubyforge_project = "meta_where"
 
-  s.add_dependency 'activerecord', '~> 3.1.0'
-  s.add_dependency 'activesupport', '~> 3.1.0'
+  s.add_dependency 'activerecord', '>= 3.0.0'
+  s.add_dependency 'activesupport', '>= 3.0.0'
   s.add_dependency 'arel', '~> 2.1.1'
   s.add_development_dependency 'shoulda'
   s.add_development_dependency 'sqlite3', '~> 1.3.3'


### PR DESCRIPTION
As per issue #28, there appears to be an issue with the dependencies specified in MetaWhere's gemspec that block using the latest version with Rails 3.1.0 RC4.
