### PR TITLE
Fixed issue with markdown escaping

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -79,7 +79,7 @@ Operators are:
 * ^ (not equal)
 * + (in array/range)
 * - (not in array/range)
-* =~ (matching -- not a regexp but a string for SQL LIKE) <b>NOTE:</b> This will override 1.9.x "symbol as string" =~ behavior.
+* \=~ (matching -- not a regexp but a string for SQL LIKE) <b>NOTE:</b> This will override 1.9.x "symbol as string" =~ behavior.
 * !~ (not matching, only available under Ruby 1.9)
 * > (greater than)
 * >= (greater than or equal to)


### PR DESCRIPTION
The bullet describing the "=~" operator was being interpreted as a header eliminating the equal sign causing confusion.
